### PR TITLE
Add styles for new "broken products" section in add-ons control panel

### DIFF
--- a/plonetheme/barceloneta/theme/less/portlets.plone.less
+++ b/plonetheme/barceloneta/theme/less/portlets.plone.less
@@ -136,7 +136,8 @@
 }
 #upgrade-products .configlets,
 #install-products .configlets,
-#activated-products .configlets {
+#activated-products .configlets,
+#broken-products .configlets {
 	li {padding: @plone-padding-base-horizontal; border-top: 1px dotted @plone-table-border-color;}
 	li:first-child {border-top: 0;}
 	h3, p {margin: 0;}


### PR DESCRIPTION
This pull request provides styles to keep the display of broken products in the Plone add-ons control panel in accordance with existing categories of products on that page.

This PR should only be merged if https://github.com/plone/Products.CMFPlone/pull/420 is merged as it is only required if HTML elements added in that PR are present.

This addresses plone/Products.CMFPlone#419