### PR TITLE
fix extending barceloneta with xi:include

### DIFF
--- a/plonetheme/barceloneta/theme/rules.xml
+++ b/plonetheme/barceloneta/theme/rules.xml
@@ -30,14 +30,6 @@
        This is important for per-section styling -->
   <copy attributes="*" css:content="body" css:theme="body" />
 
-  <!-- Central column -->
-  <xsl:variable name="central">
-    <xsl:if test="//aside[@id='portal-column-one'] and //aside[@id='portal-column-two']">col-xs-12 col-sm-6</xsl:if>
-    <xsl:if test="//aside[@id='portal-column-two'] and not(//aside[@id='portal-column-one'])">col-xs-12 col-sm-9</xsl:if>
-    <xsl:if test="//aside[@id='portal-column-one'] and not(//aside[@id='portal-column-two'])">col-xs-12 col-sm-9</xsl:if>
-    <xsl:if test="not(//aside[@id='portal-column-one']) and not(//aside[@id='portal-column-two'])">col-xs-12 col-sm-12</xsl:if>
-  </xsl:variable>
-
   <!-- move global nav -->
   <replace css:theme-children="#mainnavigation" css:content-children="#portal-mainnavigation" method="raw" />
 
@@ -48,7 +40,16 @@
   <!-- full-width breadcrumb -->
   <replace css:theme="#above-content" css:content="#viewlet-above-content"/>
 
+  <!-- Central column -->
   <replace css:theme="#content-container" method="raw">
+
+      <xsl:variable name="central">
+        <xsl:if test="//aside[@id='portal-column-one'] and //aside[@id='portal-column-two']">col-xs-12 col-sm-6</xsl:if>
+        <xsl:if test="//aside[@id='portal-column-two'] and not(//aside[@id='portal-column-one'])">col-xs-12 col-sm-9</xsl:if>
+        <xsl:if test="//aside[@id='portal-column-one'] and not(//aside[@id='portal-column-two'])">col-xs-12 col-sm-9</xsl:if>
+        <xsl:if test="not(//aside[@id='portal-column-one']) and not(//aside[@id='portal-column-two'])">col-xs-12 col-sm-12</xsl:if>
+      </xsl:variable>
+
       <div class="{$central}">
 <!--           <p class="pull-right visible-xs">
             <button type="button" class="btn btn-primary btn-xs" data-toggle="offcanvas">Toggle nav</button>


### PR DESCRIPTION
When extending the barceloneta-theme in my own theme with a xi-include like this:

    <?xml version="1.0" encoding="utf-8"?>
    <rules xmlns="http://namespaces.plone.org/diazo"
           xmlns:css="http://namespaces.plone.org/diazo/css"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
           xmlns:xi="http://www.w3.org/2001/XInclude">

      <xi:include href="/++theme++barceloneta/rules.xml" />

      <!-- Custom rules follow -->

    </rules>

Diazo throws the following error on rendering (the error is shown in the diazo-debug iframe without a traceback)

    runtime error, element 'div' [96:0]
    Variable 'central' has not been declared. [0:0]
    runtime error, element 'div' [96:0]
    Internal error: Failed to evaluate the AVT of attribute 'class'. [0:0]

When moving the rule-element <xsl:variable name="central">...</xsl:variable> into the <replace css:theme="#content-container" method="raw"> where {$central} is used it works. 

I have no clue about xstl so I don't know if this a ok change. I only think extending barceloneta like the above example is a cool thing.