### PR TITLE
Allow including barceloneta resources in a custom themes as variables

### DIFF
--- a/plonetheme/barceloneta/configure.zcml
+++ b/plonetheme/barceloneta/configure.zcml
@@ -17,6 +17,14 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <genericsetup:registerProfile
+      name="registerless"
+      title="Barceloneta Theme - Register less resources as variables"
+      directory="profiles/registerless"
+      description='This enables the compilation with the default scripts for custom Diazo themes.'
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
   <!-- Diazo themes -->
   <plone:static directory="theme" name="barceloneta" type="theme"/>
 

--- a/plonetheme/barceloneta/profiles/registerless/metadata.xml
+++ b/plonetheme/barceloneta/profiles/registerless/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1</version>
+</metadata>

--- a/plonetheme/barceloneta/profiles/registerless/registry.xml
+++ b/plonetheme/barceloneta/profiles/registerless/registry.xml
@@ -1,367 +1,374 @@
 <?xml version="1.0"?>
 <registry>
 
-<records prefix="plone.resources/fonts.plone.less"
+<records prefix="plone.resources/barceloneta-fonts"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/fonts.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/variables.plone.less"
+<records prefix="plone.resources/barceloneta-variables"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/variables.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/mixin.prefixes.plone.less"
+<records prefix="plone.resources/barceloneta-mixin-prefixes"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/mixin.prefixes.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/mixin.tabfocus.plone.less"
+<records prefix="plone.resources/barceloneta-mixin-tabfocus"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/mixin.tabfocus.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/mixin.images.plone.less"
+<records prefix="plone.resources/barceloneta-mixin-images"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/mixin.images.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/mixin.forms.plone.less"
+<records prefix="plone.resources/barceloneta-mixin-forms"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/mixin.forms.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/mixin.borderradius.plone.less"
+<records prefix="plone.resources/barceloneta-mixin-borderradius"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/mixin.borderradius.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/mixin.buttons.plone.less"
+<records prefix="plone.resources/barceloneta-mixin-buttons"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/mixin.buttons.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/mixin.clearfix.plone.less"
+<records prefix="plone.resources/barceloneta-mixin-clearfix"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/mixin.clearfix.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/mixin.gridframework.plone.less"
+<records prefix="plone.resources/barceloneta-mixin-gridframework"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/mixin.gridframework.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/mixin.grid.plone.less"
+<records prefix="plone.resources/barceloneta-mixin-grid"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/mixin.grid.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/normalize.plone.less"
+<records prefix="plone.resources/barceloneta-normalize"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/normalize.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/print.plone.less"
+<records prefix="plone.resources/barceloneta-print"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/print.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/scaffolding.plone.less"
+<records prefix="plone.resources/barceloneta-scaffolding"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/scaffolding.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/type.plone.less"
+<records prefix="plone.resources/barceloneta-type"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/type.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/code.plone.less"
+<records prefix="plone.resources/barceloneta-code"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/code.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/deco.plone.less"
+<records prefix="plone.resources/barceloneta-deco"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/deco.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/grid.plone.less"
+<records prefix="plone.resources/barceloneta-grid"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/grid.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/tables.plone.less"
+<records prefix="plone.resources/barceloneta-tables"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/tables.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/forms.plone.less"
+<records prefix="plone.resources/barceloneta-forms"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/forms.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/buttons.plone.less"
+<records prefix="plone.resources/barceloneta-buttons"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/buttons.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/states.plone.less"
+<records prefix="plone.resources/barceloneta-states"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/states.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/breadcrumbs.plone.less"
+<records prefix="plone.resources/barceloneta-breadcrumbs"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/breadcrumbs.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/pagination.plone.less"
+<records prefix="plone.resources/barceloneta-pagination"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/pagination.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/formtabbing.plone.less"
+<records prefix="plone.resources/barceloneta-formtabbing"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/formtabbing.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/views.plone.less"
+<records prefix="plone.resources/barceloneta-views"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/views.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/thumbs.plone.less"
+<records prefix="plone.resources/barceloneta-thumbs"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/thumbs.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/alerts.plone.less"
+<records prefix="plone.resources/barceloneta-alerts"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/alerts.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/portlets.plone.less"
+<records prefix="plone.resources/barceloneta-portlets"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/portlets.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/controlpanels.plone.less"
+<records prefix="plone.resources/barceloneta-controlpanels"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/controlpanels.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/tags.plone.less"
+<records prefix="plone.resources/barceloneta-tags"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/tags.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/contents.plone.less"
+<records prefix="plone.resources/barceloneta-contents"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/contents.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/accessibility.plone.less"
+<records prefix="plone.resources/barceloneta-accessibility"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/accessibility.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/toc.plone.less"
+<records prefix="plone.resources/barceloneta-toc"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/toc.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/dropzone.plone.less"
+<records prefix="plone.resources/barceloneta-dropzone"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/dropzone.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/modal.plone.less"
+<records prefix="plone.resources/barceloneta-modal"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/modal.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/pickadate.plone.less"
+<records prefix="plone.resources/barceloneta-pickadate"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/pickadate.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/sortable.plone.less"
+<records prefix="plone.resources/barceloneta-sortable"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/sortable.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/tablesorter.plone.less"
+<records prefix="plone.resources/barceloneta-tablesorter"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/tablesorter.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/tooltip.plone.less"
+<records prefix="plone.resources/barceloneta-tooltip"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/tooltip.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/tree.plone.less"
+<records prefix="plone.resources/barceloneta-tree"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/tree.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/header.plone.less"
+<records prefix="plone.resources/barceloneta-header"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/header.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/sitenav.plone.less"
+<records prefix="plone.resources/barceloneta-sitenav"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/sitenav.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/main.plone.less"
+<records prefix="plone.resources/barceloneta-main"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/main.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/footer.plone.less"
+<records prefix="plone.resources/barceloneta-footer"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/footer.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/loginform.plone.less"
+<records prefix="plone.resources/barceloneta-loginform"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/loginform.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/sitemap.plone.less"
+<records prefix="plone.resources/barceloneta-sitemap"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/sitemap.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/event.plone.less"
+<records prefix="plone.resources/barceloneta-event"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/event.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/image.plone.less"
+<records prefix="plone.resources/barceloneta-image"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/image.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/behaviors.plone.less"
+<records prefix="plone.resources/barceloneta-behaviors"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/behaviors.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/discussion.plone.less"
+<records prefix="plone.resources/barceloneta-discussion"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/discussion.plone.less</element>
     </value>
 </records>
 
-<records prefix="plone.resources/search.plone.less"
+<records prefix="plone.resources/barceloneta-search"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
     <value key="css">
       <element>++theme++barceloneta/less/search.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/barceloneta-all"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/barceloneta.plone.export.less</element>
     </value>
 </records>
 

--- a/plonetheme/barceloneta/profiles/registerless/registry.xml
+++ b/plonetheme/barceloneta/profiles/registerless/registry.xml
@@ -1,0 +1,368 @@
+<?xml version="1.0"?>
+<registry>
+
+<records prefix="plone.resources/fonts.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/fonts.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/variables.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/variables.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/mixin.prefixes.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/mixin.prefixes.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/mixin.tabfocus.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/mixin.tabfocus.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/mixin.images.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/mixin.images.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/mixin.forms.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/mixin.forms.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/mixin.borderradius.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/mixin.borderradius.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/mixin.buttons.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/mixin.buttons.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/mixin.clearfix.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/mixin.clearfix.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/mixin.gridframework.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/mixin.gridframework.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/mixin.grid.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/mixin.grid.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/normalize.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/normalize.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/print.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/print.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/scaffolding.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/scaffolding.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/type.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/type.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/code.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/code.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/deco.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/deco.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/grid.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/grid.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/tables.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/tables.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/forms.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/forms.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/buttons.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/buttons.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/states.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/states.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/breadcrumbs.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/breadcrumbs.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/pagination.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/pagination.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/formtabbing.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/formtabbing.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/views.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/views.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/thumbs.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/thumbs.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/alerts.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/alerts.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/portlets.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/portlets.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/controlpanels.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/controlpanels.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/tags.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/tags.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/contents.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/contents.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/accessibility.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/accessibility.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/toc.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/toc.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/dropzone.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/dropzone.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/modal.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/modal.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/pickadate.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/pickadate.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/sortable.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/sortable.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/tablesorter.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/tablesorter.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/tooltip.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/tooltip.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/tree.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/tree.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/header.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/header.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/sitenav.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/sitenav.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/main.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/main.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/footer.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/footer.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/loginform.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/loginform.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/sitemap.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/sitemap.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/event.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/event.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/image.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/image.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/behaviors.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/behaviors.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/discussion.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/discussion.plone.less</element>
+    </value>
+</records>
+
+<records prefix="plone.resources/search.plone.less"
+          interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="css">
+      <element>++theme++barceloneta/less/search.plone.less</element>
+    </value>
+</records>
+
+</registry>

--- a/plonetheme/barceloneta/theme/less/barceloneta.plone.export.less
+++ b/plonetheme/barceloneta/theme/less/barceloneta.plone.export.less
@@ -1,0 +1,75 @@
+//*// PLONE 5 BARCELONETA LESS AS EXPORT VARIABLES //*//
+
+// For use in Diazo themes that want to reuse the Barceloneta LESS resources.
+// You can use either this whole file or selectively pick the ones you require
+// In order to use it your theme should import the
+// plonetheme.barceloneta:registerless Generic Setup profile
+
+//*// Font families
+@import "@{fonts.plone.less}";
+
+//*// Core variables and mixins
+@import "@{variables.plone.less}";
+	@import "@{mixin.prefixes.plone.less}";
+	@import "@{mixin.tabfocus.plone.less}";
+	@import "@{mixin.images.plone.less}";
+	@import "@{mixin.forms.plone.less}";
+	@import "@{mixin.borderradius.plone.less}";
+	@import "@{mixin.buttons.plone.less}";
+	@import "@{mixin.clearfix.plone.less}";
+	@import "@{mixin.gridframework.plone.less}";
+	@import "@{mixin.grid.plone.less}";
+
+
+//*// Reset and dependencies
+@import "@{normalize.plone.less}";
+@import "@{print.plone.less}";
+
+//*// Core CSS
+@import "@{scaffolding.plone.less}";
+@import "@{type.plone.less}";
+@import "@{code.plone.less}";
+//@import "@{deco.plone.less}"; //uncomment for deco variant
+@import "@{grid.plone.less}";
+@import "@{tables.plone.less}";
+@import "@{forms.plone.less}";
+@import "@{buttons.plone.less}";
+@import "@{states.plone.less}";
+
+//*// Components
+@import "@{breadcrumbs.plone.less}";
+@import "@{pagination.plone.less}";
+@import "@{formtabbing.plone.less}";
+@import "@{views.plone.less}";
+@import "@{thumbs.plone.less}";
+@import "@{alerts.plone.less}";
+@import "@{portlets.plone.less}";
+@import "@{controlpanels.plone.less}";
+@import "@{tags.plone.less}";
+@import "@{contents.plone.less}";
+
+//*// Patterns
+@import "@{accessibility.plone.less}";
+@import "@{toc.plone.less}";
+@import "@{dropzone.plone.less}";
+@import "@{modal.plone.less}";
+@import "@{pickadate.plone.less}";
+@import "@{sortable.plone.less}";
+@import "@{tablesorter.plone.less}";
+@import "@{tooltip.plone.less}";
+@import "@{tree.plone.less}";
+
+//*// Structure
+@import "@{header.plone.less}";
+@import "@{sitenav.plone.less}";
+@import "@{main.plone.less}";
+@import "@{footer.plone.less}";
+@import "@{loginform.plone.less}";
+@import "@{sitemap.plone.less}";
+
+//*// Products
+@import "@{event.plone.less}";
+@import "@{image.plone.less}";
+@import "@{behaviors.plone.less}";
+@import "@{discussion.plone.less}";
+@import "@{search.plone.less}";

--- a/plonetheme/barceloneta/theme/less/barceloneta.plone.export.less
+++ b/plonetheme/barceloneta/theme/less/barceloneta.plone.export.less
@@ -6,70 +6,70 @@
 // plonetheme.barceloneta:registerless Generic Setup profile
 
 //*// Font families
-@import "@{fonts.plone.less}";
+@import "@{barceloneta-fonts}";
 
 //*// Core variables and mixins
-@import "@{variables.plone.less}";
-	@import "@{mixin.prefixes.plone.less}";
-	@import "@{mixin.tabfocus.plone.less}";
-	@import "@{mixin.images.plone.less}";
-	@import "@{mixin.forms.plone.less}";
-	@import "@{mixin.borderradius.plone.less}";
-	@import "@{mixin.buttons.plone.less}";
-	@import "@{mixin.clearfix.plone.less}";
-	@import "@{mixin.gridframework.plone.less}";
-	@import "@{mixin.grid.plone.less}";
+@import "@{barceloneta-variables}";
+	@import "@{barceloneta-mixin-prefixes}";
+	@import "@{barceloneta-mixin-tabfocus}";
+	@import "@{barceloneta-mixin-images}";
+	@import "@{barceloneta-mixin-forms}";
+	@import "@{barceloneta-mixin-borderradius}";
+	@import "@{barceloneta-mixin-buttons}";
+	@import "@{barceloneta-mixin-clearfix}";
+	@import "@{barceloneta-mixin-gridframework}";
+	@import "@{barceloneta-mixin-grid}";
 
 
 //*// Reset and dependencies
-@import "@{normalize.plone.less}";
-@import "@{print.plone.less}";
+@import "@{barceloneta-normalize}";
+@import "@{barceloneta-print}";
 
 //*// Core CSS
-@import "@{scaffolding.plone.less}";
-@import "@{type.plone.less}";
-@import "@{code.plone.less}";
-//@import "@{deco.plone.less}"; //uncomment for deco variant
-@import "@{grid.plone.less}";
-@import "@{tables.plone.less}";
-@import "@{forms.plone.less}";
-@import "@{buttons.plone.less}";
-@import "@{states.plone.less}";
+@import "@{barceloneta-scaffolding}";
+@import "@{barceloneta-type}";
+@import "@{barceloneta-code}";
+//@import "@{barceloneta-deco}"; //uncomment for deco variant
+@import "@{barceloneta-grid}";
+@import "@{barceloneta-tables}";
+@import "@{barceloneta-forms}";
+@import "@{barceloneta-buttons}";
+@import "@{barceloneta-states}";
 
 //*// Components
-@import "@{breadcrumbs.plone.less}";
-@import "@{pagination.plone.less}";
-@import "@{formtabbing.plone.less}";
-@import "@{views.plone.less}";
-@import "@{thumbs.plone.less}";
-@import "@{alerts.plone.less}";
-@import "@{portlets.plone.less}";
-@import "@{controlpanels.plone.less}";
-@import "@{tags.plone.less}";
-@import "@{contents.plone.less}";
+@import "@{barceloneta-breadcrumbs}";
+@import "@{barceloneta-pagination}";
+@import "@{barceloneta-formtabbing}";
+@import "@{barceloneta-views}";
+@import "@{barceloneta-thumbs}";
+@import "@{barceloneta-alerts}";
+@import "@{barceloneta-portlets}";
+@import "@{barceloneta-controlpanels}";
+@import "@{barceloneta-tags}";
+@import "@{barceloneta-contents}";
 
 //*// Patterns
-@import "@{accessibility.plone.less}";
-@import "@{toc.plone.less}";
-@import "@{dropzone.plone.less}";
-@import "@{modal.plone.less}";
-@import "@{pickadate.plone.less}";
-@import "@{sortable.plone.less}";
-@import "@{tablesorter.plone.less}";
-@import "@{tooltip.plone.less}";
-@import "@{tree.plone.less}";
+@import "@{barceloneta-accessibility}";
+@import "@{barceloneta-toc}";
+@import "@{barceloneta-dropzone}";
+@import "@{barceloneta-modal}";
+@import "@{barceloneta-pickadate}";
+@import "@{barceloneta-sortable}";
+@import "@{barceloneta-tablesorter}";
+@import "@{barceloneta-tooltip}";
+@import "@{barceloneta-tree}";
 
 //*// Structure
-@import "@{header.plone.less}";
-@import "@{sitenav.plone.less}";
-@import "@{main.plone.less}";
-@import "@{footer.plone.less}";
-@import "@{loginform.plone.less}";
-@import "@{sitemap.plone.less}";
+@import "@{barceloneta-header}";
+@import "@{barceloneta-sitenav}";
+@import "@{barceloneta-main}";
+@import "@{barceloneta-footer}";
+@import "@{barceloneta-loginform}";
+@import "@{barceloneta-sitemap}";
 
 //*// Products
-@import "@{event.plone.less}";
-@import "@{image.plone.less}";
-@import "@{behaviors.plone.less}";
-@import "@{discussion.plone.less}";
-@import "@{search.plone.less}";
+@import "@{barceloneta-event}";
+@import "@{barceloneta-image}";
+@import "@{barceloneta-behaviors}";
+@import "@{barceloneta-discussion}";
+@import "@{barceloneta-search}";


### PR DESCRIPTION
Add profile for register all the Barceloneta LESS resources for later use in Diazo themes as variables. This allow to being able to compile them with the plone-compile-resources as well.