### PR TITLE
Don't include diazo bundle in backend theme

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changelog
 - Title under thumb in albumview (closes `#1091`_).
   [polyester]
 
+- Don't include diazo bundle in backend theme
+  [instification]
+
 
 1.6.14 (2015-09-27)
 -------------------

--- a/plonetheme/barceloneta/theme/backend.xml
+++ b/plonetheme/barceloneta/theme/backend.xml
@@ -60,9 +60,11 @@
     <copy attributes="*" css:content="body" css:theme="body" />
 
     <!-- CSS -->
+    <drop css:content="head link[data-bundle='diazo']" />
     <after css:theme-children="head" css:content="head link" />
 
     <!-- Script -->
+    <drop css:content="head script[data-bundle='diazo']" />
     <after css:theme-children="head" css:content="head script" />
 
     <!-- We don't need global nav -->


### PR DESCRIPTION
In the scenario where somebody has a diazo bundle for their front-end theme but uses the backend theme for control panel/editing etc, we don't want to include the diazo bundles as it may clash with the barceloneta theme.