### PR TITLE
fix missing less variable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Add missing barceloneta less variable needed by plone.app.theming.
+  [jensens]
 
 
 1.6.18 (2016-03-31)

--- a/plonetheme/barceloneta/profiles/default/registry.xml
+++ b/plonetheme/barceloneta/profiles/default/registry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<registry>
+
+  <!-- introduce own less variable -->
+  <records prefix="plone"
+          interface="Products.ResourceRegistries.interfaces.settings.IResourceRegistriesSettings">
+    <value key="lessvariables" purge="False">
+      <element key="barcelonetaPath">\"{site_url}/++theme++barceloneta/\"</element>
+    </value>
+  </records>
+
+</registry>


### PR DESCRIPTION
less variable ``barcelonetaPath`` is used in thememappe less of plone.app.theming but was nowhere defined.