### PR TITLE
Fix for Search button problem in Plone 5.0.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,20 +1,13 @@
 Changelog
 =========
 
-1.6.19 (unreleased)
+1.6.19 (2016-04-04)
 -------------------
-
-Incompatibilities:
-
-- *add item here*
-
-New:
-
-- *add item here*
 
 Fixes:
 
-- *add item here*
+- Fixed the search button problem that occurred during translations to different languages 
+  [kkhan]
 
 
 1.6.18 (2016-03-31)

--- a/plonetheme/barceloneta/theme/less/barceloneta-compiled.css
+++ b/plonetheme/barceloneta/theme/less/barceloneta-compiled.css
@@ -3806,7 +3806,7 @@ ul.picker__list {
     max-width: 50%;
     padding-top: 0;
     position: relative;
-    width: 250px;
+    width: 260px;
   }
   #portal-searchbox .searchSection {
     display: inherit;
@@ -3815,13 +3815,14 @@ ul.picker__list {
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;
     float: left;
-    width: 180px;
+    width: 170px;
+    display:inline-block;
   }
   #portal-searchbox [type="submit"] {
     display: inline-block;
     margin-left: -1px;
     vertical-align: top;
-    width: 70px;
+    width: 90px;
   }
 }
 .plone-nav {

--- a/plonetheme/barceloneta/theme/less/barceloneta-compiled.css
+++ b/plonetheme/barceloneta/theme/less/barceloneta-compiled.css
@@ -3806,7 +3806,7 @@ ul.picker__list {
     max-width: 50%;
     padding-top: 0;
     position: relative;
-    width: 260px;
+    width: 250px;
   }
   #portal-searchbox .searchSection {
     display: inherit;
@@ -3815,14 +3815,14 @@ ul.picker__list {
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;
     float: left;
-    width: 170px;
+    width: 180px;
     display:inline-block;
   }
   #portal-searchbox [type="submit"] {
-    display: inline-block;
+    display:none;
     margin-left: -1px;
     vertical-align: top;
-    width: 90px;
+    width: 70px;
   }
 }
 .plone-nav {

--- a/plonetheme/barceloneta/theme/less/header.plone.less
+++ b/plonetheme/barceloneta/theme/less/header.plone.less
@@ -59,19 +59,20 @@
         max-width: 50%;
         padding-top: 0;
         position: relative;
-        width: 250px;
+        width: 260px;
         .searchSection {display: inherit;} //yes for non mobile
         [type="text"] {
             border-bottom-right-radius: 0;
             border-top-right-radius: 0;
             float: left;
-            width: 180px; //searchboxwidth (250px) - submit (70px)
+            width: 170px; //searchboxwidth (250px) - submit (70px)
         }
         [type="submit"] {
             display: inline-block;
             margin-left: -1px;
             vertical-align: top;
-            width: 70px;
+            width: 90px;
+            display:inline-block;
         }
     }
 }


### PR DESCRIPTION
The search button in Plone 5.0.3 is styled in order to aptly incorporate 'Search' keyword in different translations. Referring to issue: https://github.com/plone/Products.CMFPlone/issues/1154
For instance:
![fr](https://cloud.githubusercontent.com/assets/17498833/14241161/b4898f70-fa67-11e5-8692-db0020376922.png)
is converted into-
![french](https://cloud.githubusercontent.com/assets/17498833/14241137/8e382b56-fa67-11e5-9999-eac5504f0dd4.png)
