### PR TITLE
aligment tickbox for 'this section only' is off

### DIFF
--- a/plonetheme/barceloneta/theme/less/header.plone.less
+++ b/plonetheme/barceloneta/theme/less/header.plone.less
@@ -37,9 +37,6 @@
     [type="submit"] {display: none;} //submit hidden on mobile
     label {font-size: 86.667%}
 }
-#searchbox_currentfolder_only {
-    vertical-align: middle;
-}
 
 //non mobile search
 @media (min-width: @plone-grid-float-breakpoint) {


### PR DESCRIPTION
this was probably a leftover from a previous incarnation, removing the css makes it revert to correct (top) alignment.