### PR TITLE
Do not strip the #edit-bar section from the toolbar.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Do not strip the #edit-bar section from the toolbar.
+  Refs: https://github.com/plone/Products.CMFPlone/issues/2322
+  [thet]
 
 
 1.9.0 (2018-09-26)

--- a/plonetheme/barceloneta/theme/rules.xml
+++ b/plonetheme/barceloneta/theme/rules.xml
@@ -97,7 +97,7 @@
   <replace css:theme-children="#portal-footer" css:content-children="#portal-footer-wrapper" />
 
   <!-- toolbar -->
-  <replace css:theme="#portal-toolbar" css:content-children="#edit-bar" css:if-not-content=".ajax_load" css:if-content=".userrole-authenticated" />
+  <replace css:theme="#portal-toolbar" css:content="#edit-bar" css:if-not-content=".ajax_load" css:if-content=".userrole-authenticated" />
   <drop css:theme="#portal-toolbar" css:if-content=".userrole-anonymous" />
   <replace css:theme="#anonymous-actions" css:content-children="#portal-personaltools-wrapper" css:if-not-content=".ajax_load" css:if-content=".userrole-anonymous" />
 


### PR DESCRIPTION
Refs:
- https://github.com/plone/Products.CMFPlone/pull/2324
- https://github.com/plone/Products.CMFPlone/pull/2398
- https://github.com/plone/Products.CMFPlone/pull/2399

Fixes:
- https://github.com/plone/Products.CMFPlone/issues/2322
- https://github.com/plone/Products.CMFPlone/issues/2395
- https://github.com/plone/Products.CMFPlone/issues/2531

Merge together:
https://github.com/plone/Products.CMFPlone/pull/2563
https://github.com/plone/plonetheme.barceloneta/pull/165
https://github.com/plone/plone.app.upgrade/pull/180