### PR TITLE
Update footer rules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,8 @@ Changelog
 =========
 
 
-1.9.2 (unreleased)
-------------------
+1.10.0 (unreleased)
+-------------------
 
 Breaking changes:
 

--- a/plonetheme/barceloneta/theme/rules.xml
+++ b/plonetheme/barceloneta/theme/rules.xml
@@ -111,12 +111,14 @@
       css:theme-children="#portal-footer .copyright > div"
       css:content-children="#portal-footer-wrapper #portal-footer-signature .portletContent"
       />
+  <drop css:theme="#portal-footer .copyright" css:if-not-content="#portal-footer-wrapper #portal-footer-signature" />
 
   <!-- Replace colophon information with Plone version. -->
   <replace
       css:theme-children="#portal-footer .colophon > div"
       css:content-children="#portal-footer-wrapper #portal-colophon .portletContent"
       />
+  <drop css:theme="#portal-footer .colophon" css:if-not-content="#portal-footer-wrapper #portal-colophon" />
 
   <!-- Replace site-actions with Plone version. -->
   <replace

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-version = '1.9.2.dev0'
+version = '1.10.0.dev0'
 
 long_description = (
     read('README.rst') + '\n' +


### PR DESCRIPTION
remove colophon and copyright too, when not present in  content.

bump version to 1.10.0 because of breaking changes.