### PR TITLE
Add missing import for .navtree-level-loop

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ New features:
 - Additional footer portlets show in a doormat footer.
   [tmassman]
 
+Bug fixes:
+
+- Add missing import in portlets.plone.less
+  [kcleong]
 
 1.9.1 (2018-10-08)
 ------------------

--- a/plonetheme/barceloneta/theme/less/portlets.plone.less
+++ b/plonetheme/barceloneta/theme/less/portlets.plone.less
@@ -1,4 +1,5 @@
 //*// PORTLETS //*//
+@import "mixin.portlets.plone.less";
 
 .portlet {
 	border: @plone-portlet-border;


### PR DESCRIPTION
Using Plone `5.1.4` and mockup `2.7.6` with [Plone webpack](https://github.com/datakurre/plonetheme-webpack-plugin), I was getting this error:

```
(NENV)(VENV)  ✘ leong@KCs-MacBook-Pro  ~/projects/wageindicator.buildout   master ●  make watch
make -j watch_plone watch_theme
bin/instance0 fg
sleep 10 # wait for Plone
2018-11-30 16:28:28 INFO ZServer HTTP server started at Fri Nov 30 16:28:28 2018
	Hostname: 0.0.0.0
	Port: 8080
2018-11-30 16:28:31 WARNING Application Duplicate Product name: After loading Product 'GenericSetup' from '/Users/leong/projects/wageindicator.buildout/eggs/Products.GenericSetup-1.8.10-py2.7.egg/Products', I skipped the one in '/Users/leong/projects/wageindicator.buildout/VENV/lib/python2.7/site-packages/Products.GenericSetup-2.0b4-py2.7.egg/Products'.
make -C resources watch
rm -f -r .plone theme
npm run watch

> wageindicator.buildout@0.0.0 watch /Users/leong/projects/wageindicator.buildout/resources
> webpack-dev-server

/Users/leong/projects/wageindicator.buildout/eggs/grokcore.view-2.11-py2.7.egg/grokcore/view/templatereg.py:269: UserWarning: Found the following unassociated template after configuration: /Users/leong/projects/wageindicator.buildout/src/wageindicator.addon/src/wageindicator/addon/viewlets/templates/robots.pt
  warnings.warn(msg, UserWarning, 1)
/Users/leong/projects/wageindicator.buildout/eggs/grokcore.view-2.11-py2.7.egg/grokcore/view/templatereg.py:269: UserWarning: Found the following unassociated template after configuration: /Users/leong/projects/wageindicator.buildout/src/wageindicator.addon/src/wageindicator/addon/viewlets/templates/portal_header.pt
  warnings.warn(msg, UserWarning, 1)
/Users/leong/projects/wageindicator.buildout/eggs/grokcore.view-2.11-py2.7.egg/grokcore/view/templatereg.py:269: UserWarning: Found the following unassociated template after configuration: /Users/leong/projects/wageindicator.buildout/src/wageindicator.addon/src/wageindicator/addon/viewlets/templates/dublin_core.pt
  warnings.warn(msg, UserWarning, 1)
/Users/leong/projects/wageindicator.buildout/eggs/grokcore.view-2.11-py2.7.egg/grokcore/view/templatereg.py:269: UserWarning: Found the following unassociated template after configuration: /Users/leong/projects/wageindicator.buildout/src/wageindicator.addon/src/wageindicator/addon/viewlets/templates/social_tags.pt
  warnings.warn(msg, UserWarning, 1)
2018-11-30 16:28:41 INFO Zope Ready to handle requests

sauna.reload: No paths in RELOAD_PATH environment variable. Not starting fork loop.
Set it to your development egg paths to activate reloading

Example:
         $ RELOAD_PATH=src/ bin/instance fg

DEBUG mockup.less.globalVars
Project is running at http://localhost:9000/
webpack output is served from /++theme++wageindicator/
(node:21983) DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.

ERROR in ./~/css-loader?{"sourceMap":true}!./~/less-loader/dist/cjs.js?{"globalVars":{"sitePath":"'http://localhost:8080/Plone'","isPlone":true,"isMockup":false,"staticPath":"'++plone++static'","barcelonetaPath":"'++theme++barceloneta'","plone-toolbar-font-primary":"Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif","plone-toolbar-font-secondary":"Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif","plone-left-toolbar-expanded":"120px","plone-screen-sm-min":"768px","plone-toolbar-submenu-header-color":"lighten(#000, 80%)","plone-toolbar-published-color":"rgba(0,123,179,1)","mockuplessPath":"'++resource++mockupless/'","bowerPath":"'++plone++static/components/'","plone-link-color":"rgba(0,123,179,1)","plone-toolbar-internal-color":"rgb(250,184,42)","plone-container-lg":"1170px","plone-toolbar-submenu-text-color":"lighten(#000, 90%)","plone-toolbar-internally-published-color":"rgb(136,61,250)","plone-toolbar-submenu-width":"180px","mockupPath":"'++resource++mockup/'","plone-screen-sm-max":"(@plone-screen-md-min - 1)","plone-screen-md-min":"992px","plone-container-sm":"750px","plone-screen-lg-min":"1200px","plone-left-toolbar":"60px","plone-screen-md-max":"(@plone-screen-lg-min - 1)","plone-gray-lighter":"lighten(#000, 80%)","plone-toolbar-pending-color":"rgb(226,231,33)","plone-toolbar-separator-color":"rgba(255,255,255,.17)","plone-toolbar-text-color":"rgba(255,255,255,1)","plone-screen-xs-min":"480px","plone-toolbar-submenu-bg":"rgba(45,45,45,.96)","plone-toolbar-private-color":"rgb(196,24,60)","plone-screen-xs-max":"(@plone-screen-sm-min - 1)","plone-container-md":"970px","plone-toolbar-draft-color":"rgb(250,184,42)","plone-toolbar-link":"rgba(0,123,179,1)","icon-font-path":"'../fonts/'","plone-toolbar-bg":"rgba(0,0,0,.9)","plone-gray-light":"lighten(#000, 46.5%)","bootstrap-badges":"'++plone++static/components/bootstrap/less/badges.less'","bootstrap-basic":"'++plone++static/components/bootstrap/less/navbar.less'","bootstrap-button-groups":"'++plone++static/components/bootstrap/less/button-groups.less'","bootstrap-buttons":"'++plone++static/components/bootstrap/less/close.less'","bootstrap-dropdown":"'++plone++static/components/bootstrap/less/dropdowns.less'","bootstrap-glyphicons":"'++plone++static/components/bootstrap/less/glyphicons.less'","bootstrap-mixins":"'++plone++static/components/bootstrap/less/mixins.less'","bootstrap-modal":"'++plone++static/components/bootstrap/less/modals.less'","bootstrap-progress-bars":"'++plone++static/components/bootstrap/less/progress-bars.less'","bootstrap-variables":"'++plone++static/components/bootstrap/less/variables.less'","dropzone":"'++plone++static/components/dropzone/dist/dropzone.css'","jqtree":"'++plone++static/components/jqtree/jqtree.css'","jquery_recurrenceinput":"'++plone++static/components/jquery.recurrenceinput.js/src/jquery.recurrenceinput.css'","mockup-patterns-autotoc":"'++resource++mockup/autotoc/pattern.autotoc.less'","mockup-patterns-datatables":"'++resource++mockup/datatables/pattern.datatables.less'","mockup-patterns-filemanager":"'++resource++mockup/filemanager/pattern.filemanager.less'","mockup-patterns-livesearch":"'++resource++mockup/livesearch/pattern.livesearch.less'","mockup-patterns-markspeciallinks":"'++resource++mockup/markspeciallinks/pattern.markspeciallinks.less'","mockup-patterns-modal":"'++resource++mockup/modal/pattern.modal.less'","mockup-patterns-pickadate":"'++resource++mockup/pickadate/pattern.pickadate.less'","mockup-patterns-querystring":"'++resource++mockup/querystring/pattern.querystring.less'","mockup-patterns-recurrence":"'++resource++mockup/recurrence/pattern.recurrence.less'","mockup-patterns-relateditems":"'++resource++mockup/relateditems/pattern.relateditems.less'","mockup-patterns-resourceregistry":"'++resource++mockup/resourceregistry/pattern.resourceregistry.less'","mockup-patterns-select2":"'++resource++mockup/select2/pattern.select2.less'","mockup-patterns-structure":"'++resource++mockup/structure/less/pattern.structure.less'","mockup-patterns-thememapper":"'++resource++mockup/thememapper/pattern.thememapper.less'","mockup-patterns-tinymce":"'++resource++mockup/tinymce/less/pattern.tinymce.less'","mockup-patterns-tooltip":"'++resource++mockup/tooltip/pattern.tooltip.less'","mockup-patterns-tree":"'++resource++mockup/tree/pattern.tree.less'","mockup-patterns-upload":"'++resource++mockup/upload/less/pattern.upload.less'","mockup-popover":"'++resource++mockupless/popover.less'","picker":"'++plone++static/components/pickadate/lib/themes/classic.css'","picker_date":"'++plone++static/components/pickadate/lib/themes/classic.date.css'","picker_time":"'++plone++static/components/pickadate/lib/themes/classic.time.css'","plone-logged-in":"'++plone++static/plone-logged-in.less'","plone-patterns-toolbar":"'++plone++static/patterns/toolbar/src/css/toolbar.plone.less'","plone":"'++plone++static/plone.less'","plone_app_imagecropping":"'++resource++plone.app.imagecropping.static/bundle.less'","plone_app_imagecropping_cropper":"'++resource++plone.app.imagecropping.static/cropper-dist/cropper.css'","plone_app_imagecropping_cropscaleselect":"'++resource++plone.app.imagecropping.static/cropscaleselect.less'","resource-plone-app-event-event-css":"'++resource++plone.app.event/event.css'","resource-plone-app-jquerytools-dateinput-js":"'++plone++static/components/jquery.recurrenceinput.js/lib/jquery.tools.dateinput.css'","resource-plone-app-jquerytools-js":"'++plone++static/components/jquery.recurrenceinput.js/lib/jquery.tools.overlay.css'","resourceregistry":"'++plone++static/resourceregistry.less'","select2":"'++plone++static/components/select2/select2.css'","thememapper":"'++resource++plone.app.theming/thememapper.less'","tinymce-default-styles":"'++plone++static/tinymce-styles.css'","tinymce-visualblocks":"'++plone++static/components/tinymce-builded/js/tinymce/plugins/visualblocks/css/visualblocks.css'"}}!./src/wageindicator/stylesheets/theme.less
Module build failed:

		}
		.navtree-level-loop(@plone-portlet-navtree-maxlevel);
^
.navtree-level-loop is undefined
      in /Users/leong/projects/wageindicator.buildout/resources/.plone/++theme++barceloneta/less/portlets.plone.less (line 246, column 2)
 @ ./src/wageindicator/stylesheets/theme.less 4:14-147 18:2-22:4 19:20-153
 @ ./src/wageindicator/default.js
 @ multi (webpack)-dev-server/client?http://localhost:9000 webpack/hot/dev-server ./src/wageindicator/default ./src/wageindicator/logged-in
webpack: Failed to compile.
```

It seems the import is missing for `mixin.portlets.plone.less`. I've added the import in this PR.
