### PR TITLE
Load zcml of plone.resource.

### DIFF
--- a/news/2952.bugfix
+++ b/news/2952.bugfix
@@ -1,0 +1,2 @@
+Load zcml of ``plone.resource`` for our use of the ``plone:static`` directive.
+[maurits]

--- a/plonetheme/barceloneta/configure.zcml
+++ b/plonetheme/barceloneta/configure.zcml
@@ -8,6 +8,7 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="plone">
 
+  <include package="plone.resource" />
   <include package="plone.app.theming" />
   <genericsetup:registerProfile
       name="default"


### PR DESCRIPTION
This is for our use of the `plone:static` directive.
See https://github.com/plone/Products.CMFPlone/issues/2952