### PR TITLE
Change to relative xml include path to make external includes possible

### DIFF
--- a/news/212.feature
+++ b/news/212.feature
@@ -1,0 +1,2 @@
+- Change to relative xml include path to make external includes possible
+  [gomez] (#212)

--- a/plonetheme/barceloneta/theme/rules.xml
+++ b/plonetheme/barceloneta/theme/rules.xml
@@ -5,7 +5,7 @@
        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
        xmlns:xi="http://www.w3.org/2001/XInclude">
 
-  <xi:include href="grid-col-marker.xml"><xi:fallback /></xi:include>
+  <xi:include href="++theme++barceloneta/grid-col-marker.xml"/>
 
   <theme href="index.html" />
   <notheme css:if-not-content="#visual-portal-wrapper" />


### PR DESCRIPTION
We import the rules.xml form our custom theme product, unfortunaly this does not work with the existing include:
  

```2020-08-11 11:55:37,447 ERROR   [plone.subrequest:38][waitress-0] Error handling subrequest to /grid-col-marker.xml
Traceback (most recent call last):
  File "/home/gomez/.cache/buildout/eggs/Zope-4.5-py3.8.egg/ZPublisher/BaseRequest.py", line 518, in traverse
    subobject = self.traverseName(object, entry_name)
  File "/home/gomez/.cache/buildout/eggs/Zope-4.5-py3.8.egg/ZPublisher/BaseRequest.py", line 349, in traverseName
    ob2 = adapter.publishTraverse(self, name)
  File "/home/gomez/.cache/buildout/eggs/Zope-4.5-py3.8.egg/ZPublisher/BaseRequest.py", line 136, in publishTraverse
    subobject = object[name]
  File "/home/gomez/.cache/buildout/eggs/Zope-4.5-py3.8.egg/OFS/ObjectManager.py", line 840, in __getitem__
    raise KeyError(key)
KeyError: 'grid-col-marker.xml'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/gomez/.cache/buildout/eggs/plone.subrequest-1.9.2-py3.8.egg/plone/subrequest/__init__.py", line 153, in subrequest
    traversed = request.traverse(path)
  File "/home/gomez/.cache/buildout/eggs/Zope-4.5-py3.8.egg/ZPublisher/BaseRequest.py", line 535, in traverse
    return response.notFoundError(URL)
  File "/home/gomez/.cache/buildout/eggs/Zope-4.5-py3.8.egg/ZPublisher/HTTPResponse.py", line 817, in notFoundError
    raise NotFound(self._error_html(
zExceptions.NotFound: <!DOCTYPE html><html>
  <head><title>Site Error</title><meta charset="utf-8" /></head>
  <body bgcolor="#FFFFFF">
  <h2>Site Error</h2>
  <p>An error was encountered while publishing this resource.
  </p>
  <p><strong>Resource not found</strong></p>

  Sorry, the requested resource does not exist.<p>Check the URL and try again.</p><p><b>Resource:</b> http://localhost:8080/Plone/grid-col-marker.xml</p>
  <hr noshade="noshade"/>

  <p>Troubleshooting Suggestions</p>

  <ul>
  <li>The URL may be incorrect.</li>
  <li>The parameters passed to this resource may be incorrect.</li>
  <li>A resource that this resource relies on may be
      encountering an error.</li>
  </ul>

  <p>If the error persists please contact the site maintainer.
  Thank you for your patience.
  </p></body></html>
```
This PR changes it to a releative include (like done with the backend.xml). 

Tested with our custom theme (based on plonetheme.webpacktemplate) and vanilla barceloneta theme.
