### PR TITLE
Update plone.app.content templates to Bootstrap 4 

### DIFF
--- a/plonetheme/barceloneta/overrides/plone.app.content.browser.templates.select_default_page.pt
+++ b/plonetheme/barceloneta/overrides/plone.app.content.browser.templates.select_default_page.pt
@@ -1,0 +1,94 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="plone">
+
+<metal:block fill-slot="top_slot"
+             tal:define="dummy python:request.set('disable_border',1)" />
+
+  <body>
+
+    <metal:main fill-slot="main">
+      <h1 class="documentFirstHeading"
+          i18n:translate="heading_select_default_page">Select default page</h1>
+
+      <div class="documentDescription" i18n:translate="description_select_default_page">
+        Please select item which will be displayed as the default page of the
+        folder.
+      </div>
+      <div id="content-core">
+          <form name="default_page_form"
+                method="post"
+                tal:attributes="action string:${context/absolute_url}/select_default_page">
+
+            <input type="hidden" name="form.submitted" value="1"/>
+
+            <tal:items define="items view/get_selectable_items;
+                               cur_page context/getDefaultPage|nothing;">
+            <tal:hasItems condition="items"
+                          define="n_items python:len(items);
+                          member portal_state/member;
+                          portal_visible_ids context/portal_properties/site_properties/visible_ids|nothing;
+                          member_visible_ids python:member.getProperty('visible_ids', context.portal_memberdata.getProperty('visible_ids'))">
+                <dl>
+                    <tal:item repeat="item items">
+                        <dt tal:define="normalized_type python:plone_view.normalizeString(item.portal_type);
+                                        item_id python:'(%s)' % item.getId if (portal_visible_ids and member_visible_ids) else ''">
+                            <input type="radio" name="objectId" value=""
+                                tal:attributes="value item/getId;
+                                                id item/getId;
+                                                checked python: (n_items==1 or item.getId==cur_page) and 'checked' or None;"/>
+                            <label tal:attributes="for item/getId;
+                                                   class string:contenttype-${normalized_type}"
+                                   tal:content="string:${item/pretty_title_or_id} $item_id">
+                                Item title
+                            </label>
+                        </dt>
+                        <dd tal:content="item/Description">
+                            Item Description
+                        </dd>
+                    </tal:item>
+
+                </dl>
+
+              <div class="formControls">
+                <input class="context"
+                       type="submit"
+                       name="form.buttons.Save"
+                       value="Save"
+                       i18n:attributes="value label_save;"
+                       />
+                <input
+                       type="submit"
+                       name="form.buttons.Cancel"
+                       value="Cancel"
+                       i18n:attributes="value label_cancel;"
+                       />
+              </div>
+
+            </tal:hasItems>
+            <tal:noitems condition="not:nocall:items">
+              <div i18n:translate="help_no_selectable_default_pages">
+                 There are no items in this folder that can be selected as
+                 a default view page.
+              </div>
+              <div class="formControls">
+                    <input class="context"
+                       type="submit"
+                       name="form.button.Cancel"
+                       value="Ok"
+                       i18n:attributes="value label_ok;"
+                       />
+              </div>
+            </tal:noitems>
+            </tal:items>
+
+          </form>
+      </div>
+
+    </metal:main>
+
+  </body>
+</html>

--- a/plonetheme/barceloneta/overrides/plone.app.content.browser.templates.select_default_page.pt
+++ b/plonetheme/barceloneta/overrides/plone.app.content.browser.templates.select_default_page.pt
@@ -53,19 +53,17 @@
 
                 </dl>
 
-              <div class="formControls">
-                <input class="context"
+              <div class="formControls form-group">
+                <button class="context btn btn-primary"
                        type="submit"
                        name="form.buttons.Save"
                        value="Save"
-                       i18n:attributes="value label_save;"
-                       />
-                <input
+                       i18n:attributes="value label_save;">Save</button>
+                <button class="btn btn-secondary"
                        type="submit"
                        name="form.buttons.Cancel"
                        value="Cancel"
-                       i18n:attributes="value label_cancel;"
-                       />
+                       i18n:attributes="value label_cancel;">Cancel</button>
               </div>
 
             </tal:hasItems>
@@ -74,13 +72,12 @@
                  There are no items in this folder that can be selected as
                  a default view page.
               </div>
-              <div class="formControls">
-                    <input class="context"
+              <div class="formControls form-group">
+                    <button class="context btn btn-primary"
                        type="submit"
                        name="form.button.Cancel"
                        value="Ok"
-                       i18n:attributes="value label_ok;"
-                       />
+                       i18n:attributes="value label_ok;">Ok</button>
               </div>
             </tal:noitems>
             </tal:items>

--- a/plonetheme/barceloneta/overrides/plone.app.content.browser.templates.select_default_view.pt
+++ b/plonetheme/barceloneta/overrides/plone.app.content.browser.templates.select_default_view.pt
@@ -1,0 +1,92 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="plone">
+
+<metal:block fill-slot="top_slot"
+             tal:define="dummy python:request.set('disable_border',1)" />
+
+  <body>
+
+    <metal:main fill-slot="main">
+
+      <h1 class="documentFirstHeading"
+          i18n:translate="heading_select_default_view">Select default view</h1>
+
+      <div class="documentDescription" i18n:translate="description_select_default_view">
+        Please select which template should be used as the default view of the
+        folder.
+      </div>
+
+      <div id="content-core">
+          <form name="default_view_form"
+                action="."
+                method="post"
+                tal:attributes="action view/action_url">
+
+            <input type="hidden" name="form.submitted" value="1"/>
+
+                <div tal:define="selectedLayout view/selectedLayout;">
+                    <tal:item repeat="layout view/vocab">
+                        <tal:vars define="value python:layout[0];
+                                          display python:layout[1];">
+                            <input type="radio" class="noborder" name="templateId" value=""
+                                   tal:attributes="value value;
+                                                   id value;
+                                                   disabled python:value==selectedLayout"/>
+                            <label for="" tal:content="display"
+                                   i18n:translate=""
+                                   tal:attributes="for value">
+                                Layout name
+                            </label>
+                            <span class="discreet"
+                                  tal:condition="python:value==selectedLayout"
+                                  i18n:translate="label_current">(current)</span><br />
+                        </tal:vars>
+                    </tal:item>
+                    <p tal:condition="view/canSelectDefaultPage">
+                        <tal:selected condition="python:selectedLayout != ''">
+                            <span i18n:translate="label_or">or</span>
+                            <a title="Select an item to be used as default view in this folder" href="#" class="selected"
+                               tal:attributes="href string:${context/absolute_url}/select_default_page;"
+                               i18n:attributes="title title_select_default_page;"
+                               i18n:translate="label_choose_content_item">
+                                 Choose a content item&hellip;
+                            </a>
+                        </tal:selected>
+                        <tal:selected condition="python:selectedLayout == ''">
+                            <span i18n:translate="label_or">or</span>
+                            <a title="Change the item used as default view in this folder" href="#" class="selected"
+                               tal:attributes="href string:${context/absolute_url}/select_default_page;"
+                               i18n:attributes="title title_change_default_view_item;"
+                               i18n:translate="label_select_content_item">
+                                 Select a content item&hellip;
+                            </a>
+                        </tal:selected>
+                    </p>
+                </div>
+
+              <div class="formControls">
+                <input class="context"
+                       type="submit"
+                       name="form.button.Save"
+                       value="Save"
+                       i18n:attributes="value label_save;"
+                       />
+                <input class="standalone"
+                       type="submit"
+                       name="form.button.Cancel"
+                       value="Cancel"
+                       i18n:attributes="value label_cancel;"
+                       />
+              </div>
+
+          </form>
+      </div>
+
+    </metal:main>
+
+  </body>
+</html>

--- a/plonetheme/barceloneta/overrides/plone.app.content.browser.templates.select_default_view.pt
+++ b/plonetheme/barceloneta/overrides/plone.app.content.browser.templates.select_default_view.pt
@@ -68,19 +68,17 @@
                     </p>
                 </div>
 
-              <div class="formControls">
-                <input class="context"
+              <div class="formControls form-group">
+                <button class="context btn btn-primary"
                        type="submit"
                        name="form.button.Save"
                        value="Save"
-                       i18n:attributes="value label_save;"
-                       />
-                <input class="standalone"
+                       i18n:attributes="value label_save;">Save</button>
+                <button class="standalone btn btn-secondary"
                        type="submit"
                        name="form.button.Cancel"
                        value="Cancel"
-                       i18n:attributes="value label_cancel;"
-                       />
+                       i18n:attributes="value label_cancel;">Cancel</button>
               </div>
 
           </form>


### PR DESCRIPTION
Following the guidelines in https://github.com/plone/Products.CMFPlone/issues/2967 and https://github.com/plone/plone.app.content/issues/196 I've updated the following templates from plone.app.content:

- plone.app.content.browser.templates.select_default_view.pt
- plone.app.content.browser.templates.select_default_page.pt

Decisions:

- Use buttons instead of inputs for the form submissions; 
- Use 'btn-primary' for "form.buttons.Save" actions
- Use 'btn-secondary' for "form.buttons.Cancel" actions