### PR TITLE
Also leave #edit-bar intact when copying the toolbar html into the theme using backend.xml

### DIFF
--- a/news/3191.bugfix
+++ b/news/3191.bugfix
@@ -1,0 +1,1 @@
+Also leave #edit-bar intact when copying the toolbar html into the theme using backend.xml, as was fixed two years to in the normal rules.xml. [fredvd]

--- a/plonetheme/barceloneta/theme/backend.xml
+++ b/plonetheme/barceloneta/theme/backend.xml
@@ -25,7 +25,7 @@
     -->
 
   <!-- Toolbar -->
-  <before css:theme-children="body" css:content-children="#edit-bar" css:if-not-content=".ajax_load" css:if-content=".userrole-authenticated" />
+  <before css:theme-children="body" css:content="#edit-bar" css:if-not-content=".ajax_load" css:if-content=".userrole-authenticated" />
   <replace css:theme="#anonymous-actions" css:content-children="#portal-personaltools-wrapper" css:if-not-content=".ajax_load" css:if-content=".userrole-anonymous" />
 
   <!-- We don't want overlays -->


### PR DESCRIPTION
as was fixed two years to in the normal rules.xml