### PR TITLE
Use make-row mixin for portal-header thus it has the flex-wrap: wrap

### DIFF
--- a/news/241.feature
+++ b/news/241.feature
@@ -1,0 +1,2 @@
+Update to Bootstrap 5.0.1
+[agitator]

--- a/scss/header.scss
+++ b/scss/header.scss
@@ -47,8 +47,7 @@
 
   @include media-breakpoint-up($nav-main-breakpoint) {
     position: relative;
-    display: flex;
-    flex-direction: row;
+    @include make-row(0rem);
   }
 
 }


### PR DESCRIPTION
This just uses the mixin to make portal-header a bootstrap row. The code does it already but not set the flex-wrap: wrap by default, while the row does it. The change is enabled only when viewport is over than $nav-main-breakpoint.

Note: bootstrap mixin row add some margin to the row, so using 0rem as parameter for make-row permit the logo to be aligned with the main navigation as before.