### PR TITLE
Footer portlet fixes

### DIFF
--- a/news/281.bugfix
+++ b/news/281.bugfix
@@ -1,0 +1,2 @@
+Show footer portlets when managing all portlets from @@manage-portlets
+[frapell]

--- a/plonetheme/barceloneta/theme/rules.xml
+++ b/plonetheme/barceloneta/theme/rules.xml
@@ -107,7 +107,7 @@
             <xsl:when css:test=".card">
               <xsl:choose>
                 <xsl:when css:test=".card-header:not(.titleless)">
-                  <div class="headline"><h2><xsl:value-of css:select=".card-header" /></h2></div>
+                  <div class="headline"><h2><xsl:apply-templates select="./node()[@class='card-header']/node()" /></h2></div>
                 </xsl:when>
               </xsl:choose>
               <xsl:choose>

--- a/plonetheme/barceloneta/theme/rules.xml
+++ b/plonetheme/barceloneta/theme/rules.xml
@@ -63,6 +63,8 @@
   <after css:theme-children="#portal-column-two" css:content-children="#portal-column-two"></after>
   <drop css:theme="#portal-column-two" css:if-not-content="#portal-column-two" />
 
+  <!-- manage-portlets Footer portlets -->
+  <after css:theme-children="#portal-footer-wrapper" css:content-children="#portal-footer-wrapper" css:if-content="#portal-footer-wrapper #portletmanager-plone-footerportlets"></after>
 
   <!-- Footer -->
   <xsl:variable name="footer_portlets" select="//footer[@id='portal-footer-wrapper']//div[@class='portletWrapper']/*[not(contains(@id,'portal-colophon')) and not(contains(@id,'portal-footer-signature')) and not(contains(@class,'portletActions'))]"></xsl:variable>


### PR DESCRIPTION
This branch fixes https://github.com/plone/plonetheme.barceloneta/issues/281

In addition, I went ahead and included an extra fix. When you create a static text portlet, you can specify a "Details link" that will be used to wrap the header and footer of the portlet itself with an `<a>` tag. This works fine with portlets in the left and the right, but the footer portlets loose the link for the header. 

Since it was a small fix, I decided to include here. Let me know if I should revert that change, and create a separate issue and PR for that.