### PR TITLE
disable diazo for manage-viewlets view

### DIFF
--- a/news/303.bugfix
+++ b/news/303.bugfix
@@ -1,0 +1,2 @@
+disable diazo for manage-viewlets view, because Diazo is messing with viewlets and viewlet manager, which is more confusing than helpful
+  [MrTango]

--- a/plonetheme/barceloneta/theme/rules.xml
+++ b/plonetheme/barceloneta/theme/rules.xml
@@ -9,6 +9,7 @@
 
   <theme href="index.html" />
   <notheme css:if-not-content="#visual-portal-wrapper" />
+  <notheme css:if-content=".template-manage-viewlets" />
 
   <rules css:if-content="#portal-top">
     <!-- Attributes -->


### PR DESCRIPTION
The reason for this is, that this view often misses some viewlets or viewlet managers and is very confusing.
It is helping people more when it stays unstyled.