### PR TITLE
Fix Diazo rule problem with undefined footer_portlets and footer_port…

### DIFF
--- a/news/239.bugfix
+++ b/news/239.bugfix
@@ -1,0 +1,3 @@
+Fix Diazo rule problem with undefined footer_portlets and footer_portlets_count variables.
+
+See: https://community.plone.org/t/error-theme-inherited-from-barceloneta-footer-portlets-count/8455

--- a/plonetheme/barceloneta/theme/rules.xml
+++ b/plonetheme/barceloneta/theme/rules.xml
@@ -67,10 +67,6 @@
   <!-- manage-portlets Footer portlets -->
   <after css:theme-children="#portal-footer-wrapper" css:content-children="#portal-footer-wrapper" css:if-content="#portal-footer-wrapper #portletmanager-plone-footerportlets"></after>
 
-  <!-- Footer -->
-  <xsl:variable name="footer_portlets" select="//footer[@id='portal-footer-wrapper']//div[@class='portletWrapper']/*[not(contains(@id,'portal-colophon')) and not(contains(@id,'portal-footer-signature')) and not(contains(@class,'portletActions'))]"></xsl:variable>
-  <xsl:variable name="footer_portlets_count" select="count($footer_portlets)"></xsl:variable>
-
   <!-- Replace footer information with Plone version. -->
   <replace
       css:theme-children="#portal-footer .copyright > div"
@@ -94,6 +90,8 @@
 
   <!-- Move all other footer portlets into doormat area. -->
   <replace css:theme-children="#portal-footer .doormat">
+    <xsl:variable name="footer_portlets" select="//footer[@id='portal-footer-wrapper']//div[@class='portletWrapper']/*[not(contains(@id,'portal-colophon')) and not(contains(@id,'portal-footer-signature')) and not(contains(@class,'portletActions'))]"></xsl:variable>
+    <xsl:variable name="footer_portlets_count" select="count($footer_portlets)"></xsl:variable>
     <xsl:variable name="columns">
       <xsl:if test="$footer_portlets_count=1">col-md-12</xsl:if>
       <xsl:if test="$footer_portlets_count=2">col-md-6</xsl:if>


### PR DESCRIPTION
…lets_count variables.

See: https://community.plone.org/t/error-theme-inherited-from-barceloneta-footer-portlets-count/8455

Cherry-pick for Plone 6.0 of: https://github.com/plone/plonetheme.barceloneta/pull/239