### PR TITLE
Updated backend.xml

### DIFF
--- a/plonetheme/barceloneta/theme/backend.xml
+++ b/plonetheme/barceloneta/theme/backend.xml
@@ -51,8 +51,10 @@
     <notheme css:if-not-content="#visual-portal-wrapper" />
 
     <!-- We can't control the bundle from here due to include. Just hard code -->
+   
     <after css:theme-children="head">
-      <link href="++theme++barceloneta/css/barceloneta.css"
+    <!-- I changed the stylesheet path from an absolute one (starting with "/") to a relative path (starting with "./") -->
+      <link href="./++theme++barceloneta/css/barceloneta.css"
             rel="stylesheet"
       />
     </after>


### PR DESCRIPTION
I changed the stylesheet path from an absolute one (starting with "/") to a relative path (starting with "./"). This adjustment ensures that when the website is hosted in a subfolder, like `http://somesite.com/plonesite/`, the stylesheet is correctly located and loaded relative to the subfolder. The original absolute path caused the browser to look for the stylesheet at the root of the entire website, leading to loading errors when the site was in a subfolder. The relative path directs the browser to the correct location, resolving the problem and ensuring the stylesheet is applied as intended within the subfolder context.