### PR TITLE
don't drop class attribute in edit bar for backend.xml - Plone 6.0

### DIFF
--- a/news/359.bugfix
+++ b/news/359.bugfix
@@ -1,0 +1,2 @@
+pat-plone-modal works fine now and also this would remove "nav-link dropdown-item" classes, unstyling the menu entries
+[yurj]

--- a/plonetheme/barceloneta/theme/backend.xml
+++ b/plonetheme/barceloneta/theme/backend.xml
@@ -39,11 +39,6 @@
            css:theme="#anonymous-actions"
   />
 
-  <!-- We don't want overlays -->
-  <drop attributes="class"
-        css:content="#edit-bar a.pat-plone-modal"
-  />
-
   <!-- Cut down barceloneta without just for backend UI -->
   <rules css:if-not-content="body.viewpermission-view, body.viewpermission-none">
 


### PR DESCRIPTION
pat-plone-modal works fine now and also this would remove "nav-link dropdown-item" classes, unstyling the menu entries
[yurj]