### PR TITLE
Add the portal_url parameter to be used with Diazo rules

### DIFF
--- a/news/376.feature
+++ b/news/376.feature
@@ -1,0 +1,1 @@
+[yurj] Add the portal_url parameter to be used with Diazo rules and implement it in backend.xml

--- a/plonetheme/barceloneta/theme/backend.xml
+++ b/plonetheme/barceloneta/theme/backend.xml
@@ -47,7 +47,7 @@
 
     <!-- We can't control the bundle from here due to include. Just hard code -->
     <after css:theme-children="head">
-      <link href="++theme++barceloneta/css/barceloneta.css"
+      <link href="{$portal_url}/++theme++barceloneta/css/barceloneta.css"
             rel="stylesheet"
       />
     </after>

--- a/plonetheme/barceloneta/theme/manifest.cfg
+++ b/plonetheme/barceloneta/theme/manifest.cfg
@@ -14,3 +14,6 @@ production-css = ++theme++barceloneta/css/barceloneta.min.css
 tinymce-content-css = /++theme++barceloneta/css/barceloneta.min.css
 development-js =
 production-js =
+
+[theme:parameters]
+# portal_url = python: portal.absolute_url()

--- a/plonetheme/barceloneta/theme/manifest.cfg
+++ b/plonetheme/barceloneta/theme/manifest.cfg
@@ -16,4 +16,4 @@ development-js =
 production-js =
 
 [theme:parameters]
-# portal_url = python: portal.absolute_url()
+portal_url = portal_state/portal_url


### PR DESCRIPTION
Looking at this rule, for example:

```xml
    <!-- We can't control the bundle from here due to include. Just hard code -->
    <after css:theme-children="head">
      <link href="++theme++barceloneta/css/barceloneta.css"
            rel="stylesheet"
      />
    </after>
```
the css will be loaded relative to the content. This is problematic:

- different url for the same css file, cache problems
- traversing private content can lead to "Insufficient privileges" while the resource itself is public

This PR add the portal_url variable in the theme parameters (manifest.cfg) and apply it in backend.xml