### PR TITLE
Fix classic toolbar scrolling on small height screens

### DIFF
--- a/news/3908.bugfix
+++ b/news/3908.bugfix
@@ -1,0 +1,2 @@
+Fix classic toolbar scrolling on small height screens.
+

--- a/scss/_toolbar.scss
+++ b/scss/_toolbar.scss
@@ -22,6 +22,8 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    overflow-y: auto;
+    overflow-x: hidden;
     background: var(--plone-toolbar-bg);
     width: var(--plone-toolbar-width);
     color: var(--plone-toolbar-text-color);


### PR DESCRIPTION
Contributes to #3908

Adds vertical scrolling to the Classic UI toolbar when the viewport height
It is small, preventing toolbar items from being cut off.
